### PR TITLE
Update Build template

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,58 +1,62 @@
-<div align=center>
+# 🚀 ErrorX vVERSION Released!
 
-[![Release Downloads](https://img.shields.io/github/downloads/FakeErrorX/ErrorX/vVERSION/total?style=flat-square&logo=github)](https://img.shields.io/github/downloads/FakeErrorX/ErrorX/vVERSION/)
+<div align="center">
 
-</div>
-
-**Download based on your OS:**
-
-<div align=left>
-<table>
-    <thead align=left>
-        <tr>
-            <th>OS</th>
-            <th>Download</th>
-        </tr>
-    </thead>
-    <tbody align=left>
-        <tr>
-        <td>Android</td>
-            <td>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-android-arm64-v8a.apk"><img src="https://img.shields.io/badge/APK-ARMv8-168039.svg?logo=android"></a><br>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-android-armeabi-v7a.apk"><img src="https://img.shields.io/badge/APK-ARMv7-45bf55.svg?logo=android"></a><br>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-android-x86_64.apk"><img src="https://img.shields.io/badge/APK-x64-96ed89.svg?logo=android"></a>
-            </td>
-        </tr>
-        <tr>
-            <td>Windows</td>
-            <td>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-windows-amd64-setup.exe"><img src="https://img.shields.io/badge/Setup-x64-2d7d9a.svg?logo=windows"></a><br>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-windows-amd64.zip"><img src="https://img.shields.io/badge/Portable-x64-67b7d1.svg?logo=windows"></a>
-            </td>
-        </tr>
-        <tr>
-            <td>macOS</td>
-            <td>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-macos-arm64.dmg"><img src="https://img.shields.io/badge/DMG-Apple%20Silicon-%23000000.svg?logo=apple"></a><br>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-macos-amd64.dmg"><img src="https://img.shields.io/badge/DMG-Intel%20X64-%2300A9E0.svg?logo=apple"></a><br>
-            </td>
-        </tr>
-        <tr>
-            <td>Linux</td>
-            <td>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-linux-amd64.AppImage"><img src="https://img.shields.io/badge/AppImage-x64-f84e29.svg?logo=linux"> </a><br>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-linux-amd64.deb"><img src="https://img.shields.io/badge/DebPackage-x64-FF9966.svg?logo=debian"> </a><br>
-                <a href="https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-linux-amd64.deb"><img src="https://img.shields.io/badge/RpmPackage-x64-F1B42F.svg?logo=redhat"> </a>
-            </td>
-        </tr>
-    </tbody>
-</table>
-
+![Release Downloads](https://img.shields.io/github/downloads/FakeErrorX/ErrorX/vVERSION/total?style=for-the-badge&logo=github&color=blue)
+![GitHub Release](https://img.shields.io/github/v/release/FakeErrorX/ErrorX?style=for-the-badge&logo=github)
+![License](https://img.shields.io/github/license/FakeErrorX/ErrorX?style=for-the-badge)
 
 </div>
 
-<div dir="ltr">
+---
 
-**List of all changes:** [ChangeLog](https://github.com/FakeErrorX/ErrorX/blob/main/CHANGELOG.md)
+## 📥 Download for Your Platform
+
+<div align="center">
+
+| 🖥️ **Platform** | 📦 **Downloads** |
+|:---:|:---:|
+| **🤖 Android** | [![APK ARMv8](https://img.shields.io/badge/APK%20ARMv8-168039?style=for-the-badge&logo=android)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-android-arm64-v8a.apk)<br>[![APK ARMv7](https://img.shields.io/badge/APK%20ARMv7-45bf55?style=for-the-badge&logo=android)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-android-armeabi-v7a.apk)<br>[![APK x64](https://img.shields.io/badge/APK%20x64-96ed89?style=for-the-badge&logo=android)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-android-x86_64.apk) |
+| **🪟 Windows** | [![Setup x64](https://img.shields.io/badge/Setup%20x64-2d7d9a?style=for-the-badge&logo=windows)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-windows-amd64-setup.exe)<br>[![Portable x64](https://img.shields.io/badge/Portable%20x64-67b7d1?style=for-the-badge&logo=windows)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-windows-amd64.zip) |
+| **🍎 macOS** | [![DMG Apple Silicon](https://img.shields.io/badge/DMG%20Apple%20Silicon-000000?style=for-the-badge&logo=apple)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-macos-arm64.dmg)<br>[![DMG Intel x64](https://img.shields.io/badge/DMG%20Intel%20x64-00A9E0?style=for-the-badge&logo=apple)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-macos-amd64.dmg) |
+| **🐧 Linux** | [![AppImage x64](https://img.shields.io/badge/AppImage%20x64-f84e29?style=for-the-badge&logo=linux)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-linux-amd64.AppImage)<br>[![Deb Package](https://img.shields.io/badge/Deb%20Package-FF9966?style=for-the-badge&logo=debian)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-linux-amd64.deb)<br>[![RPM Package](https://img.shields.io/badge/RPM%20Package-F1B42F?style=for-the-badge&logo=redhat)](https://github.com/FakeErrorX/ErrorX/releases/download/vVERSION/ErrorX-VERSION-linux-amd64.rpm) |
+
+</div>
+
+---
+
+## 📋 What's New
+
+<div align="center">
+
+📝 **[📖 Full Changelog](https://github.com/FakeErrorX/ErrorX/blob/main/CHANGELOG.md)** • 🐛 **[Report Issues](https://github.com/FakeErrorX/ErrorX/issues)** • ⭐ **[Star Project](https://github.com/FakeErrorX/ErrorX)**
+
+</div>
+
+---
+
+## 🔧 System Requirements
+
+- **Android**: Android 5.0+ (API 21+)
+- **Windows**: Windows 10/11 (x64)
+- **macOS**: macOS 10.15+ (Intel/Apple Silicon)
+- **Linux**: Ubuntu 18.04+, Debian 10+, CentOS 8+
+
+---
+
+## 🚀 Quick Start
+
+1. **Download** the appropriate version for your platform
+2. **Install** and launch ErrorX
+3. **Configure** your BDIX connection
+4. **Connect** and enjoy optimized internet!
+
+---
+
+<div align="center">
+
+**🌟 If you find ErrorX useful, please consider giving us a star! 🌟**
+
+[![GitHub stars](https://img.shields.io/github/stars/FakeErrorX/ErrorX?style=social)](https://github.com/FakeErrorX/ErrorX)
 
 </div>

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
             os: macos-13
             arch: amd64
           - platform: macos
-            os: macos-latest
+            os: macos-15
             arch: arm64
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,154 +1,105 @@
-# <div align="center">⚡ ErrorX</div>
-
 <div align="center">
-  
-  <!-- Badges with modern design -->
-  [![Release](https://img.shields.io/github/v/release/FakeErrorX/ErrorX?style=for-the-badge&logo=github&color=blue&logoColor=white)](https://github.com/FakeErrorX/ErrorX/releases)
-  [![Downloads](https://img.shields.io/github/downloads/FakeErrorX/ErrorX/total?style=for-the-badge&logo=github&color=blue&logoColor=white)](https://github.com/FakeErrorX/ErrorX/releases)
-  [![License](https://img.shields.io/github/license/FakeErrorX/ErrorX?style=for-the-badge&color=blue&logoColor=white)](LICENSE)
-  [![Telegram](https://img.shields.io/badge/Telegram-Channel-blue?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ErrorX_BD)
 
-  <br/>
-  
-  *A powerful multi-platform ErrorX BDIX client based on ClashMeta*
-  
-  [📥 Download](#download) • [🚀 Features](#features) • [🛠️ Build](#build) • [📱 Platforms](#platforms)
+# ⚡ ErrorX  ⚡ 
 
+[![Release](https://img.shields.io/github/v/release/FakeErrorX/ErrorX?style=for-the-badge&logo=github&color=blue&logoColor=white)](https://github.com/FakeErrorX/ErrorX/releases)
+[![Downloads](https://img.shields.io/github/downloads/FakeErrorX/ErrorX/total?style=for-the-badge&logo=github&color=blue&logoColor=white)](https://github.com/FakeErrorX/ErrorX/releases)
+[![License](https://img.shields.io/github/license/FakeErrorX/ErrorX?style=for-the-badge&color=blue&logoColor=white)](LICENSE)
+[![Telegram](https://img.shields.io/badge/Telegram-Channel-blue?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ErrorX_BD)
+[![Discord](https://img.shields.io/badge/Discord-Server-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sG8FYe8Npf)
+
+<br/>
+
+ **A powerful multi-platform ErrorX BDIX client based on ClashMeta**
+ 
 </div>
 
 ---
 
-## 🌟 Highlights
+## 📱 Supported Platforms
 
-- 🔒 **Privacy First**: Open-source and completely ad-free
-- 🎨 **Modern UI**: Material You Design with Surfboard-like interface
-- 🌓 **Customizable**: Multiple color themes and dark mode support
-- 🔄 **Flexible**: Subscription link support
-- 📱 **Adaptive**: Optimized for all screen sizes
+<div align="center">
 
-## 🚀 Features
+| Platform | Status |
+|:---:|:---:|
+| 🤖 **Android** | ✅ Stable |
+| 🪟 **Windows** | ✅ Stable |
+| 🍎 **macOS** | ✅ Stable |
+| 🐧 **Linux** | ✅ Stable |
 
-<table>
-<tr>
-<td>
+</div>
 
-### 🎯 Core Features
-- Material You Design
-- WebDAV Sync Support
-- Dark Mode
-- Subscription Management
-- Multi-language Support
-
-</td>
-<td>
-
-### ✨ Advanced Features
-- Custom Rules
-- Traffic Statistics
-- Profile Management
-- System Proxy
-- Quick Actions
-
-</td>
-</tr>
-</table>
-
-## 📱 Platforms
-
-ErrorX runs seamlessly on:
-
-- **🤖 Android**
-- **🪟 Windows**
-- **🍎 macOS**
-- **🐧 Linux**
-
-## 🛠️ Installation
-
-### 📱 Android
-
-Quick actions support:
-```bash
-net.errorx.vpn.action.START
-net.errorx.vpn.action.STOP
-net.errorx.vpn.action.CHANGE
-```
-
-### 🐧 Linux
-
-Required dependencies:
-```bash
-sudo apt-get install appindicator3-0.1 libappindicator3-dev
-sudo apt-get install keybinder-3.0
-```
+---
 
 ## 📥 Download
 
 <div align="center">
-  <a href="https://github.com/FakeErrorX/ErrorX/releases">
-    <img src="snapshots/get-it-on-github.svg" alt="Get it on GitHub" width="240px"/>
-  </a>
+
+[![Get it on GitHub](https://img.shields.io/badge/Download%20Latest-2EA44F?style=for-the-badge&logo=github&logoColor=white)](https://github.com/FakeErrorX/ErrorX/releases/latest)
+
+*Choose your platform and download the latest version*
+
 </div>
 
-## 🛠️ Build Guide
+### 📋 System Requirements
 
-### Prerequisites
-- Flutter SDK
-- Golang environment
-- Git
+- **Android**: Android 5.0+ (API 21+)
+- **Windows**: Windows 10/11 (x64)
+- **macOS**: macOS 10.15+ (Intel/Apple Silicon)
+- **Linux**: Ubuntu 18.04+, Debian 10+, CentOS 8+
 
-### Steps
+### 🔧 Linux Dependencies
 
-1. Clone and update submodules:
-   ```bash
-   git submodule update --init --recursive
-   ```
+<div align="center">
 
-2. Build for your platform:
+**Required packages for Linux systems to ensure full functionality**
 
-   <details>
-   <summary>📲 Android Build</summary>
-   
-   Requirements:
-   - Android SDK
-   - Android NDK
-   - Set ANDROID_NDK environment variable
-   
-   ```bash
-   dart ./setup.dart android
-   ```
-   </details>
+</div>
 
-   <details>
-   <summary>🪟 Windows Build</summary>
-   
-   Requirements:
-   - Windows system
-   - GCC compiler
-   - Inno Setup
-   
-   ```bash
-   dart ./setup.dart windows --arch <arm64 | amd64>
-   ```
-   </details>
+<details>
+<summary><b>🐧 Ubuntu/Debian Systems</b></summary>
 
-   <details>
-   <summary>🐧 Linux Build</summary>
-   
-   ```bash
-   dart ./setup.dart linux --arch <arm64 | amd64>
-   ```
-   </details>
+```bash
+sudo apt-get update
+sudo apt-get install appindicator3-0.1 libappindicator3-dev
+sudo apt-get install keybinder-3.0
+```
 
-   <details>
-   <summary>🍎 macOS Build</summary>
-   
-   ```bash
-   dart ./setup.dart macos --arch <arm64 | amd64>
-   ```
-   </details>
+</details>
+
+<details>
+<summary><b>🔴 CentOS/RHEL/Fedora Systems</b></summary>
+
+```bash
+sudo yum update
+sudo yum install libappindicator-gtk3-devel
+sudo yum install keybinder3-devel
+```
+
+</details>
+
+<div align="center">
+</div>
+
+<div align="center">
+
+**🌟 If you find ErrorX useful, please consider giving us a star! 🌟**
+
+[![GitHub stars](https://img.shields.io/github/stars/FakeErrorX/ErrorX?style=social)](https://github.com/FakeErrorX/ErrorX)
+
+**Made with ❤️ by the ErrorX Team**
+
+[![Telegram](https://img.shields.io/badge/Join%20Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ErrorX_BD)
+[![Discord](https://img.shields.io/badge/Join%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sG8FYe8Npf)
+
+</div>
 
 ---
 
 <div align="center">
-  Made with ❤️ by ErrorX Team
+
+This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
+
 </div>
+
+---


### PR DESCRIPTION
Updated .github/release_template.md and README.md with improved formatting, modern badges, clearer download/platform sections, and enhanced instructions for users. Also updated macOS build target in build.yaml to use macos-15 for arm64 builds. These changes improve clarity, accessibility, and visual appeal for users and contributors.